### PR TITLE
Itc 956

### DIFF
--- a/app/Controller/ServicesController.php
+++ b/app/Controller/ServicesController.php
@@ -1772,7 +1772,7 @@ class ServicesController extends AppController
         }
 
         $ContactsInherited = $this->__inheritContactsAndContactgroups($service, $_service);
-//			debug($service);
+
         $service['Host'] = $_service['Host'];
         $service['NotifyPeriod'] = $_service['NotifyPeriod'];
         $service['CheckPeriod'] = $_service['CheckPeriod'];

--- a/app/Controller/ServicetemplatesController.php
+++ b/app/Controller/ServicetemplatesController.php
@@ -480,7 +480,7 @@ class ServicetemplatesController extends AppController
                     }
                 }
 
-                if(oldServicetemplateEventkCommandId != $this->request->data['Servicetemplate']['eventhandler_command_id']){
+                if($oldServicetemplateEventkCommandId != $this->request->data['Servicetemplate']['eventhandler_command_id']){
                     //Event handler command of service template was changed
                     //Delete all custom event handler command arguments of services
                     //if eventhandler_command_id from Service is NULL

--- a/app/Model/Hosttemplate.php
+++ b/app/Model/Hosttemplate.php
@@ -73,6 +73,7 @@ class Hosttemplate extends AppModel
             'dependent'  => true,
         ],
         'Hosttemplatecommandargumentvalue',
+        'Host'
     ];
 
     var $validate = [

--- a/app/View/Hosttemplates/edit.ctp
+++ b/app/View/Hosttemplates/edit.ctp
@@ -44,7 +44,7 @@ $notification_settings = [
             <?php echo __('Monitoring'); ?>
             <span>>
                 <?php echo __('Hosttemplate'); ?>
-			</span>
+            </span>
             <div class="third_level"> <?php echo ucfirst($this->params['action']); ?></div>
         </h1>
     </div>
@@ -289,6 +289,7 @@ $notification_settings = [
                                 'class'     => 'chosen col col-xs-12',
                                 'label'     => ['text' => __('Checkcommand'), 'class' => 'col-xs-1 col-md-1 col-lg-1'],
                                 'wrapInput' => 'col col-xs-10 col-md-10 col-lg-10',
+                                'help'             => '<span class="text-danger">'.__('Warning: If you change the check command, all host custom arguments will be reset to host template default!').'</span>'
                             ]);
                             ?>
                             <!-- Command arguments -->

--- a/app/View/Servicetemplates/edit.ctp
+++ b/app/View/Servicetemplates/edit.ctp
@@ -290,7 +290,7 @@ $notification_settings = [
                                 'label'            => ['text' => '<a href="/commands/edit/'.$this->request->data['Servicetemplate']['command_id'].'"><i class="fa fa-cog"></i> </a>'.__('Checkcommand'), 'class' => 'col-xs-1 col-md-1 col-lg-1'],
                                 'class'            => 'chosen col col-xs-12',
                                 'wrapInput'        => 'col col-xs-10 col-md-10 col-lg-10',
-                                'help'             => __('Warning: If you change the check command, all service custom arguments will be reset to default!')
+                                'help'             => '<span class="text-danger">'.__('Warning: If you change the check command, all service custom arguments will be reset to service template default!').'</span>'
                             ]);
                             ?>
                             <!-- Command arguments -->
@@ -492,6 +492,7 @@ $notification_settings = [
                                 'label'            => ['text' => __('Eventhandler'), 'class' => 'col-xs-1 col-md-1 col-lg-1'],
                                 'class'            => 'chosen col col-xs-12',
                                 'wrapInput'        => 'col col-xs-10 col-md-10 col-lg-10',
+                                'help'             => '<span class="text-danger">'.__('Warning: If you change the event handler command, all service custom arguments will be reset to service template default!').'</span>'
                             ]); ?>
                             <div id="EventhandlerCommandArgs"></div>
                             <br>

--- a/app/View/Servicetemplates/edit.ctp
+++ b/app/View/Servicetemplates/edit.ctp
@@ -46,7 +46,7 @@ $notification_settings = [
             <?php echo __('Monitoring'); ?>
             <span>>
                 <?php echo __('Servicetemplate'); ?>
-			</span>
+            </span>
             <div class="third_level"> <?php echo ucfirst($this->params['action']); ?></div>
         </h1>
     </div>
@@ -290,6 +290,7 @@ $notification_settings = [
                                 'label'            => ['text' => '<a href="/commands/edit/'.$this->request->data['Servicetemplate']['command_id'].'"><i class="fa fa-cog"></i> </a>'.__('Checkcommand'), 'class' => 'col-xs-1 col-md-1 col-lg-1'],
                                 'class'            => 'chosen col col-xs-12',
                                 'wrapInput'        => 'col col-xs-10 col-md-10 col-lg-10',
+                                'help'             => __('Warning: If you change the check command, all service custom arguments will be reset to default!')
                             ]);
                             ?>
                             <!-- Command arguments -->


### PR DESCRIPTION
Delete custom service command Argument values and event handler command argument values, if you change the check command / event handler command of a service template, and the service has no own check command

Delete custom host command argument values, if you change the check command of a host template, and the host has no own check command