### PR TITLE
Prevent memory leak

### DIFF
--- a/app/node/ChartRenderer.js
+++ b/app/node/ChartRenderer.js
@@ -168,6 +168,9 @@ app.post('/AreaChart', function(request, response){
         .then(function(buffer){
             response.writeHead(200, {'Content-Type': 'image/png'});
             response.end(buffer, 'binary');
+        })
+        .finally(() => {
+            chartNode.destroy();
         });
 });
 


### PR DESCRIPTION
When running openITCOCKPIT for a long time the nodejs server running ChartRenderer.js consumes more and more memory. This should fix it. See https://github.com/vmpowerio/chartjs-node/issues/30