### PR TITLE
Hide Command Line by Default and Enable Command Line Copy

### DIFF
--- a/src/Template/Hosts/browser.php
+++ b/src/Template/Hosts/browser.php
@@ -391,10 +391,32 @@ use Cake\Core\Plugin;
 
                                             <tr>
                                                 <td><?php echo __('Command line'); ?></td>
+                                                <input type='text' style='display:none;' id='hostCommandLine-copy'
+                                                       value='{{ mergedHost.hostCommandLine }}'>
                                                 <td>
-                                                    <code class="no-background">
+                                                    <code ng-class="{'macroPassword': hideCommand}">
                                                         {{ mergedHost.hostCommandLine }}
                                                     </code>
+                                                    <button class='btn btn-default txt-color-red btn-icon btn-sm'
+                                                            title="<?php echo __('Hide Command Line'); ?>"
+                                                            ng-click='hideCommand = 1'
+                                                            ng-hide='hideCommand'>
+                                                        <i class='fa fa-eye-slash'></i>
+                                                    </button>
+
+                                                    <button class='btn btn-default txt-color-blue btn-icon btn-sm'
+                                                            title="<?php echo __('Show Command Line'); ?>"
+                                                            ng-click='hideCommand = 0'
+                                                            ng-show='hideCommand'>
+                                                        <i class='fa fa-eye'></i>
+                                                    </button>
+
+                                                    <button class='btn btn-default txt-color-blue btn-icon btn-sm'
+                                                            title="<?php echo __('Copy Command Line'); ?>"
+                                                            onclick="$('#hostCommandLine-copy').show().select();document.execCommand('copy');$('#hostCommandLine-copy').hide();"
+                                                            ng-click='copyCommand'>
+                                                        <i class='fa fa-copy'></i>
+                                                    </button>
                                                 </td>
                                             </tr>
 

--- a/src/Template/Services/browser.php
+++ b/src/Template/Services/browser.php
@@ -460,10 +460,35 @@ use Cake\Core\Plugin;
 
                                             <tr>
                                                 <td><?php echo __('Command line'); ?></td>
+                                                <input type='text' style='display:none;' id='serviceCommandLine-copy'
+                                                       value='{{ mergedService.serviceCommandLine }}'>
                                                 <td>
-                                                    <code class="no-background">
+                                                    <code ng-class="{'macroPassword': hideCommand}">
                                                         {{ mergedService.serviceCommandLine }}
                                                     </code>
+
+                                                    <button class='btn btn-default txt-color-red btn-icon btn-sm'
+                                                            title="<?php echo __('Hide Command Line'); ?>"
+                                                            ng-click='hideCommand = 1'
+                                                            ng-hide='hideCommand'>
+                                                        <i class='fa fa-eye-slash'></i>
+                                                    </button>
+
+                                                    <button class='btn btn-default txt-color-blue btn-icon btn-sm'
+                                                            title="<?php echo __('Show Command Line'); ?>"
+                                                            ng-click='hideCommand = 0'
+                                                            ng-show='hideCommand'>
+                                                        <i class='fa fa-eye'></i>
+                                                    </button>
+
+                                                    <button class='btn btn-default txt-color-blue btn-icon btn-sm'
+                                                            title="<?php echo __('Copy Command Line'); ?>"
+                                                            onclick="$('#serviceCommandLine-copy').show().select();document.execCommand('copy');$('#serviceCommandLine-copy').hide();"
+                                                            ng-click="copyCommand">
+                                                        <i class='fa fa-copy'></i>
+                                                    </button>
+
+
                                                 </td>
                                             </tr>
 

--- a/webroot/js/scripts/controllers/Hosts/HostsBrowserController.js
+++ b/webroot/js/scripts/controllers/Hosts/HostsBrowserController.js
@@ -23,6 +23,8 @@ angular.module('openITCOCKPIT')
 
         $scope.canSubmitExternalCommands = false;
 
+        $scope.hideCommand = 1;
+
         $scope.tags = [];
 
         $scope.pingResult = [];

--- a/webroot/js/scripts/controllers/Services/ServicesBrowserController.js
+++ b/webroot/js/scripts/controllers/Services/ServicesBrowserController.js
@@ -9,6 +9,8 @@ angular.module('openITCOCKPIT')
 
         $scope.canSubmitExternalCommands = false;
 
+        $scope.hideCommand = 1;
+
         $scope.tags = [];
 
         $scope.init = true;


### PR DESCRIPTION
Hi IT Novum,
Could you set the command line that it's hidden by default, in the submitted code the JavaScript file will initially hide always but this is probably better as a system setting, but I didn't want to fiddle too much and create a new system setting.

Ideally only those users with the correct permission should be able to see the command line if not then it should be removed completely from the HTML (a new setting) but that's a bigger ask.

I've also added a clipboard copy function.