### PR TITLE
ITC-2580 Hide Command Line by Default and Enable Command Line Copy

### DIFF
--- a/src/Controller/HostsController.php
+++ b/src/Controller/HostsController.php
@@ -1863,6 +1863,8 @@ class HostsController extends AppController {
         $User = new User($this->getUser());
         $UserTime = $User->getUserTime();
 
+        $canUserSeeCheckCommand = isset($this->PERMISSIONS['hosts']['checkcommand']);
+
         /** @var SystemsettingsTable $SystemsettingsTable */
         $SystemsettingsTable = TableRegistry::getTableLocator()->get('Systemsettings');
 
@@ -2126,6 +2128,12 @@ class HostsController extends AppController {
         }
 
         $canSubmitExternalCommands = $this->hasPermission('externalcommands', 'hosts');
+
+        if ($canUserSeeCheckCommand === false) {
+            $mergedHost['hostCommandLine'] = 'Removed due to insufficient permissions';
+            $mergedHost['hostcommandargumentvalues'] = 'Removed due to insufficient permissions';
+            $checkCommand = 'Removed due to insufficient permissions';
+        }
 
         // Set data to fronend
         $this->set('mergedHost', $mergedHost);

--- a/src/Controller/HostsController.php
+++ b/src/Controller/HostsController.php
@@ -1872,7 +1872,9 @@ class HostsController extends AppController {
             //Only ship template
 
             $masterInstanceName = $SystemsettingsTable->getMasterInstanceName();
+            $blurryCommandLine = $SystemsettingsTable->blurCheckCommand();
             $this->set('masterInstanceName', $masterInstanceName);
+            $this->set('blurryCommandLine', $blurryCommandLine);
             $this->set('username', $User->getFullName());
             return;
         }

--- a/src/Controller/ServicesController.php
+++ b/src/Controller/ServicesController.php
@@ -1331,6 +1331,9 @@ class ServicesController extends AppController {
     public function browser($idOrUuid = null) {
         $User = new User($this->getUser());
         $UserTime = $User->getUserTime();
+
+        $canUserSeeCheckCommand = isset($this->PERMISSIONS['services']['checkcommand']);
+
         if ($this->isHtmlRequest()) {
             /** @var SystemsettingsTable $SystemsettingsTable */
             $SystemsettingsTable = TableRegistry::getTableLocator()->get('Systemsettings');
@@ -1696,6 +1699,12 @@ class ServicesController extends AppController {
 
         $typesForView = $ServicesTable->getServiceTypesWithStyles();
         $serviceType = $typesForView[$mergedService['service_type']];
+
+        if ($canUserSeeCheckCommand === false) {
+            $mergedService['serviceCommandLine'] = 'Removed due to insufficient permissions';
+            $mergedService['servicecommandargumentvalues'] = 'Removed due to insufficient permissions';
+            $checkCommand = 'Removed due to insufficient permissions';
+        }
 
         // Set data to fronend
         $this->set('mergedService', $mergedService);

--- a/src/Controller/ServicesController.php
+++ b/src/Controller/ServicesController.php
@@ -1338,9 +1338,11 @@ class ServicesController extends AppController {
             /** @var SystemsettingsTable $SystemsettingsTable */
             $SystemsettingsTable = TableRegistry::getTableLocator()->get('Systemsettings');
             $masterInstanceName = $SystemsettingsTable->getMasterInstanceName();
+            $blurryCommandLine = $SystemsettingsTable->blurCheckCommand();
 
             //Only ship template
             $this->set('username', $User->getFullName());
+            $this->set('blurryCommandLine', $blurryCommandLine);
             $this->set('masterInstanceName', $masterInstanceName);
             return;
         }

--- a/src/Model/Table/SystemsettingsTable.php
+++ b/src/Model/Table/SystemsettingsTable.php
@@ -195,6 +195,18 @@ class SystemsettingsTable extends Table {
     }
 
     /**
+     * @return bool
+     */
+    public function blurCheckCommand() {
+        if (!Cache::read('systemsettings_blur_command_line_in_browser', 'permissions')) {
+            $settings = $this->findAsArraySection('FRONTEND');
+            $value = $settings['FRONTEND']['FRONTEND.BLUR_COMMAND_LINE_IN_BROWSER'] === '1';
+            Cache::write('systemsettings_blur_command_line_in_browser', $value, 'permissions');
+        }
+        return Cache::read('systemsettings_blur_command_line_in_browser', 'permissions');
+    }
+
+    /**
      * @param string $key
      * @return array
      */

--- a/src/Template/Hosts/browser.php
+++ b/src/Template/Hosts/browser.php
@@ -27,6 +27,7 @@
  * @var \App\View\AppView $this
  * @var string $masterInstanceName
  * @var string $username
+ * @var bool $blurryCommandLine
  */
 
 use Cake\Core\Plugin;
@@ -392,23 +393,26 @@ use Cake\Core\Plugin;
 
                                                 <tr>
                                                     <td><?php echo __('Command line'); ?></td>
-                                                    <td class="copy-to-clipboard-container">
-                                                        <code class="no-background">
+                                                    <td class="copy-to-clipboard-container"
+                                                        style="display: block; position: relative;">
+                                                        <code
+                                                            class="no-background <?php echo $blurryCommandLine ? 'unblur-on-hover' : '' ?>">
                                                             {{ mergedHost.hostCommandLine }}
                                                         </code>
 
-                                                        <div class="copy-to-clipboard-btn copy-to-clipboard-btn-top-right"
-                                                             rel="tooltip"
-                                                             data-toggle="tooltip"
-                                                             data-trigger="click"
-                                                             data-placement="left"
-                                                             data-original-title="<?= __('Copied'); ?>">
-                                                            <span
+                                                        <div
+                                                            class="copy-to-clipboard-btn copy-to-clipboard-btn-top-right"
+                                                            rel="tooltip"
+                                                            data-toggle="tooltip"
+                                                            data-trigger="click"
+                                                            data-placement="left"
+                                                            data-original-title="<?= __('Copied'); ?>">
+                                                            <div
                                                                 class="btn btn-default btn-xs waves-effect waves-themed"
                                                                 ng-click="clipboardCommand()"
                                                                 title="<?php echo __('Copy to clipboard'); ?>">
-                                                            <i class="fa fa-copy"></i>
-                                                            </span>
+                                                                <i class="fa fa-copy"></i>
+                                                            </div>
                                                         </div>
                                                     </td>
                                                 </tr>

--- a/src/Template/Hosts/browser.php
+++ b/src/Template/Hosts/browser.php
@@ -376,27 +376,29 @@ use Cake\Core\Plugin;
                                 <div class="row">
                                     <div class="col-xs-12 col-sm-12 col-md-9">
                                         <table class="table table-bordered table-sm">
-                                            <tr>
-                                                <td><?php echo __('Check command'); ?></td>
-                                                <td>
-                                                    <?php if ($this->Acl->hasPermission('edit', 'commands')): ?>
-                                                        <a ui-sref="CommandsEdit({id: checkCommand.Command.id})">
+                                            <?php if ($this->Acl->hasPermission('checkcommand', 'hosts')): ?>
+                                                <tr>
+                                                    <td><?php echo __('Check command'); ?></td>
+                                                    <td>
+                                                        <?php if ($this->Acl->hasPermission('edit', 'commands')): ?>
+                                                            <a ui-sref="CommandsEdit({id: checkCommand.Command.id})">
+                                                                {{ checkCommand.Command.name }}
+                                                            </a>
+                                                        <?php else: ?>
                                                             {{ checkCommand.Command.name }}
-                                                        </a>
-                                                    <?php else: ?>
-                                                        {{ checkCommand.Command.name }}
-                                                    <?php endif; ?>
-                                                </td>
-                                            </tr>
+                                                        <?php endif; ?>
+                                                    </td>
+                                                </tr>
 
-                                            <tr>
-                                                <td><?php echo __('Command line'); ?></td>
-                                                <td>
-                                                    <code class="no-background">
-                                                        {{ mergedHost.hostCommandLine }}
-                                                    </code>
-                                                </td>
-                                            </tr>
+                                                <tr>
+                                                    <td><?php echo __('Command line'); ?></td>
+                                                    <td>
+                                                        <code class="no-background">
+                                                            {{ mergedHost.hostCommandLine }}
+                                                        </code>
+                                                    </td>
+                                                </tr>
+                                            <?php endif; ?>
 
                                             <tr>
                                                 <td><?php echo __('Output'); ?></td>
@@ -913,8 +915,8 @@ use Cake\Core\Plugin;
                                                 <i class="fa fa-refresh fa-spin txt-primary"></i>
                                             </span>
                                             <span ng-show="failureDurationInPercent">{{ (failureDurationInPercent) ?
-                                                failureDurationInPercent+' %' :
-                                                '<?php echo __('No data available !'); ?>'}}
+                                                    failureDurationInPercent + ' %' :
+                                                    '<?php echo __('No data available!'); ?>'}}
                                             </span>
                                         </h3></div>
                                     <div class="col-12">

--- a/src/Template/Hosts/browser.php
+++ b/src/Template/Hosts/browser.php
@@ -392,10 +392,24 @@ use Cake\Core\Plugin;
 
                                                 <tr>
                                                     <td><?php echo __('Command line'); ?></td>
-                                                    <td>
+                                                    <td class="copy-to-clipboard-container">
                                                         <code class="no-background">
                                                             {{ mergedHost.hostCommandLine }}
                                                         </code>
+
+                                                        <div class="copy-to-clipboard-btn copy-to-clipboard-btn-top-right"
+                                                             rel="tooltip"
+                                                             data-toggle="tooltip"
+                                                             data-trigger="click"
+                                                             data-placement="left"
+                                                             data-original-title="<?= __('Copied'); ?>">
+                                                            <span
+                                                                class="btn btn-default btn-xs waves-effect waves-themed"
+                                                                ng-click="clipboardCommand()"
+                                                                title="<?php echo __('Copy to clipboard'); ?>">
+                                                            <i class="fa fa-copy"></i>
+                                                            </span>
+                                                        </div>
                                                     </td>
                                                 </tr>
                                             <?php endif; ?>

--- a/src/Template/Packetmanager/index.php
+++ b/src/Template/Packetmanager/index.php
@@ -360,7 +360,13 @@ $Logo = new \itnovum\openITCOCKPIT\Core\Views\Logo();
                 </div>
 
                 <div class="row padding-top-5">
-                    <div class="col-lg-12">
+
+                    <!--
+                    If you change this command please make also sure to change the command
+                    in the PackagemanagerIndexController clipboardCommand function !!
+                    -->
+
+                    <div class="col-lg-12 copy-to-clipboard-container" style="display: block; position: relative;">
                         <div class="bg-color-black txt-color-white code-font padding-7 packetmanager-selection">
                             sudo apt-get update && apt-get dist-upgrade
                             <br>
@@ -368,6 +374,21 @@ $Logo = new \itnovum\openITCOCKPIT\Core\Views\Logo();
                             \ <br>
                             && echo "#########################################" \ <br>
                             && echo "<?= __('Installation done. Please reload your {0} web interface.', $systemname) ?>"
+                        </div>
+                        <div
+                            class="copy-to-clipboard-btn copy-to-clipboard-btn-top-right"
+                            style="right: 20px;"
+                            rel="tooltip"
+                            data-toggle="tooltip"
+                            data-trigger="click"
+                            data-placement="left"
+                            data-original-title="<?= __('Copied'); ?>">
+                            <div
+                                class="btn btn-default btn-xs waves-effect waves-themed"
+                                ng-click="clipboardCommand()"
+                                title="<?php echo __('Copy to clipboard'); ?>">
+                                <i class="fa fa-copy"></i>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/Template/Services/browser.php
+++ b/src/Template/Services/browser.php
@@ -461,10 +461,24 @@ use Cake\Core\Plugin;
 
                                                 <tr>
                                                     <td><?php echo __('Command line'); ?></td>
-                                                    <td>
+                                                    <td class="copy-to-clipboard-container">
                                                         <code class="no-background">
                                                             {{ mergedService.serviceCommandLine }}
                                                         </code>
+
+                                                        <div class="copy-to-clipboard-btn copy-to-clipboard-btn-top-right"
+                                                             rel="tooltip"
+                                                             data-toggle="tooltip"
+                                                             data-trigger="click"
+                                                             data-placement="left"
+                                                             data-original-title="<?= __('Copied'); ?>">
+                                                            <span
+                                                                class="btn btn-default btn-xs waves-effect waves-themed"
+                                                                ng-click="clipboardCommand()"
+                                                                title="<?php echo __('Copy to clipboard'); ?>">
+                                                            <i class="fa fa-copy"></i>
+                                                            </span>
+                                                        </div>
                                                     </td>
                                                 </tr>
                                             <?php endif; ?>

--- a/src/Template/Services/browser.php
+++ b/src/Template/Services/browser.php
@@ -26,6 +26,7 @@
 /**
  * @var \App\View\AppView $this
  * @var string $username
+ * @var bool $blurryCommandLine
  */
 
 use Cake\Core\Plugin;
@@ -38,9 +39,9 @@ use Cake\Core\Plugin;
 
 
 <service-browser-menu
-        ng-if="serviceBrowserMenuConfig"
-        config="serviceBrowserMenuConfig"
-        last-load-date="lastLoadDate"></service-browser-menu>
+    ng-if="serviceBrowserMenuConfig"
+    config="serviceBrowserMenuConfig"
+    last-load-date="lastLoadDate"></service-browser-menu>
 
 
 <reschedule-service callback="showFlashMsg"></reschedule-service>
@@ -144,11 +145,11 @@ use Cake\Core\Plugin;
                                     </div>
                                     <div class="col-6">
                                             <span
-                                                    ng-if="mergedService.active_checks_enabled && host.Host.is_satellite_host === false">
+                                                ng-if="mergedService.active_checks_enabled && host.Host.is_satellite_host === false">
                                                 {{ servicestatus.nextCheck }}
                                             </span>
                                         <span
-                                                ng-if="mergedService.active_checks_enabled == 0 || host.Host.is_satellite_host === true">
+                                            ng-if="mergedService.active_checks_enabled == 0 || host.Host.is_satellite_host === true">
                                             <?php echo __('n/a'); ?>
                                         </span>
                                     </div>
@@ -233,7 +234,7 @@ use Cake\Core\Plugin;
 
                         <div class="row" style="display: flex;">
                             <div
-                                    class="col-xs-12 col-sm-6 col-md-7 col-lg-9 padding-bottom-10 padding-left-10 padding-right-10">
+                                class="col-xs-12 col-sm-6 col-md-7 col-lg-9 padding-bottom-10 padding-left-10 padding-right-10">
                                 <div class="alert alert-danger opacity-80 margin-bottom-5" role="alert"
                                      ng-show="mergedService.disabled">
                                     <div class="d-flex align-items-center">
@@ -293,9 +294,9 @@ use Cake\Core\Plugin;
                                                 <div class="col-lg-12">
                                                     <?php if ($this->Acl->hasPermission('delete', 'downtimes')): ?>
                                                         <button
-                                                                class="btn btn-xs btn-danger float-right"
-                                                                ng-if="downtime.allowEdit && downtime.isCancellable"
-                                                                ng-click="confirmServiceDowntimeDelete(getObjectForDowntimeDelete())">
+                                                            class="btn btn-xs btn-danger float-right"
+                                                            ng-if="downtime.allowEdit && downtime.isCancellable"
+                                                            ng-click="confirmServiceDowntimeDelete(getObjectForDowntimeDelete())">
                                                             <i class="fa fa-trash"></i> <?php echo __('Delete'); ?>
                                                         </button>
                                                     <?php endif; ?>
@@ -400,9 +401,9 @@ use Cake\Core\Plugin;
                                                 <div class="col-lg-12">
                                                     <?php if ($this->Acl->hasPermission('delete', 'downtimes')): ?>
                                                         <button
-                                                                class="btn btn-xs btn-danger float-right"
-                                                                ng-if="hostDowntime.allowEdit && hostDowntime.isCancellable"
-                                                                ng-click="confirmHostDowntimeDelete(getObjectForHostDowntimeDelete())">
+                                                            class="btn btn-xs btn-danger float-right"
+                                                            ng-if="hostDowntime.allowEdit && hostDowntime.isCancellable"
+                                                            ng-click="confirmHostDowntimeDelete(getObjectForHostDowntimeDelete())">
                                                             <i class="fa fa-trash"></i> <?php echo __('Delete'); ?>
                                                         </button>
                                                     <?php endif; ?>
@@ -461,23 +462,26 @@ use Cake\Core\Plugin;
 
                                                 <tr>
                                                     <td><?php echo __('Command line'); ?></td>
-                                                    <td class="copy-to-clipboard-container">
-                                                        <code class="no-background">
+                                                    <td class="copy-to-clipboard-container"
+                                                        style="display: block; position: relative;">
+                                                        <code
+                                                            class="no-background <?php echo $blurryCommandLine ? 'unblur-on-hover' : '' ?>">
                                                             {{ mergedService.serviceCommandLine }}
                                                         </code>
 
-                                                        <div class="copy-to-clipboard-btn copy-to-clipboard-btn-top-right"
-                                                             rel="tooltip"
-                                                             data-toggle="tooltip"
-                                                             data-trigger="click"
-                                                             data-placement="left"
-                                                             data-original-title="<?= __('Copied'); ?>">
-                                                            <span
+                                                        <div
+                                                            class="copy-to-clipboard-btn copy-to-clipboard-btn-top-right"
+                                                            rel="tooltip"
+                                                            data-toggle="tooltip"
+                                                            data-trigger="click"
+                                                            data-placement="left"
+                                                            data-original-title="<?= __('Copied'); ?>">
+                                                            <div
                                                                 class="btn btn-default btn-xs waves-effect waves-themed"
                                                                 ng-click="clipboardCommand()"
                                                                 title="<?php echo __('Copy to clipboard'); ?>">
-                                                            <i class="fa fa-copy"></i>
-                                                            </span>
+                                                                <i class="fa fa-copy"></i>
+                                                            </div>
                                                         </div>
                                                     </td>
                                                 </tr>
@@ -499,7 +503,7 @@ use Cake\Core\Plugin;
                                                     </code>
                                                 </td>
                                             </tr>
-                                            <tr  ng-show="servicestatus.currentState > 0">
+                                            <tr ng-show="servicestatus.currentState > 0">
                                                 <td>
                                                     <?php echo __('Last time'); ?>
                                                     <span class="badge badge-success" style="margin-right: 2px;">
@@ -554,9 +558,9 @@ use Cake\Core\Plugin;
                                 <?php if (\Cake\Core\Plugin::isLoaded('PrometheusModule')): ?>
                                     <!-- Prometheus state overview table -->
                                     <prometheus-service-browser
-                                            ng-if="mergedService.service_type === <?= PROMETHEUS_SERVICE ?>"
-                                            service-id="mergedService.id"
-                                            last-load="lastLoadDate"></prometheus-service-browser>
+                                        ng-if="mergedService.service_type === <?= PROMETHEUS_SERVICE ?>"
+                                        service-id="mergedService.id"
+                                        last-load="lastLoadDate"></prometheus-service-browser>
                                 <?php endif; ?>
 
                                 <!-- Host state overview table -->
@@ -576,8 +580,8 @@ use Cake\Core\Plugin;
                                             <tr>
                                                 <td class="text-center">
                                                     <hoststatusicon
-                                                            ng-if="hoststatus"
-                                                            state="hoststatus.currentState"
+                                                        ng-if="hoststatus"
+                                                        state="hoststatus.currentState"
                                                     ></hoststatusicon>
                                                 </td>
                                                 <td>
@@ -604,12 +608,12 @@ use Cake\Core\Plugin;
 
 
                                     <div
-                                            class="col-xs-12 col-sm-12 col-md-6 text-info"
-                                            ng-hide="areContactsFromService">
+                                        class="col-xs-12 col-sm-12 col-md-6 text-info"
+                                        ng-hide="areContactsFromService">
                                         <?php echo __('Contacts and contact groups got inherited from'); ?>
 
                                         <span
-                                                ng-class="{'bold': areContactsInheritedFromServicetemplate}">
+                                            ng-class="{'bold': areContactsInheritedFromServicetemplate}">
                                                 <?php if ($this->Acl->hasPermission('edit', 'servicetemplates')): ?>
                                                     <a ui-sref="ServicetemplatesEdit({id: mergedService.servicetemplate_id})">
                                                         <?php echo __('service template'); ?>
@@ -789,14 +793,14 @@ use Cake\Core\Plugin;
                                         <div><?php echo __('Next check'); ?></div>
                                         <h3 class="margin-top-0">
                                                 <span
-                                                        ng-if="mergedService.active_checks_enabled && host.Host.is_satellite_host === false">
+                                                    ng-if="mergedService.active_checks_enabled && host.Host.is_satellite_host === false">
                                                     {{ servicestatus.nextCheck }}
                                                     <small style="color: #333;" ng-show="servicestatus.latency > 1">
                                                         (+ {{ servicestatus.latency }})
                                                     </small>
                                                 </span>
                                             <span
-                                                    ng-if="mergedService.active_checks_enabled == 0 || host.Host.is_satellite_host === true">
+                                                ng-if="mergedService.active_checks_enabled == 0 || host.Host.is_satellite_host === true">
                                             <?php echo __('n/a'); ?>
 
 
@@ -938,9 +942,9 @@ use Cake\Core\Plugin;
                                                 <td>
                                                     <code>{{ host.Host.uuid }}</code>
                                                     <span
-                                                            class="btn btn-default btn-xs"
-                                                            onclick="$('#host-uuid-copy').show().select();document.execCommand('copy');$('#host-uuid-copy').hide();"
-                                                            title="<?php echo __('Copy to clipboard'); ?>">
+                                                        class="btn btn-default btn-xs"
+                                                        onclick="$('#host-uuid-copy').show().select();document.execCommand('copy');$('#host-uuid-copy').hide();"
+                                                        title="<?php echo __('Copy to clipboard'); ?>">
                                                             <i class="fa fa-copy"></i>
                                                         </span>
                                                     <input type="text" style="display:none;" id="host-uuid-copy"
@@ -952,9 +956,9 @@ use Cake\Core\Plugin;
                                                 <td>
                                                     <code>{{ mergedService.uuid }}</code>
                                                     <span
-                                                            class="btn btn-default btn-xs"
-                                                            onclick="$('#service-uuid-copy').show().select();document.execCommand('copy');$('#service-uuid-copy').hide();"
-                                                            title="<?php echo __('Copy to clipboard'); ?>">
+                                                        class="btn btn-default btn-xs"
+                                                        onclick="$('#service-uuid-copy').show().select();document.execCommand('copy');$('#service-uuid-copy').hide();"
+                                                        title="<?php echo __('Copy to clipboard'); ?>">
                                                             <i class="fa fa-copy"></i>
                                                         </span>
                                                     <input type="text" style="display:none;" id="service-uuid-copy"
@@ -964,7 +968,8 @@ use Cake\Core\Plugin;
                                             <tr>
                                                 <td><?php echo __('Service type'); ?></td>
                                                 <td>
-                                                    <span class="badge border margin-right-10 {{serviceType.class}} {{serviceType.color}}">
+                                                    <span
+                                                        class="badge border margin-right-10 {{serviceType.class}} {{serviceType.color}}">
                                                         <i class="{{serviceType.icon}}"></i>
                                                         {{serviceType.title}}
                                                     </span>
@@ -1041,8 +1046,8 @@ use Cake\Core\Plugin;
                                                 <td><?php echo __('Satellite'); ?></td>
                                                 <td>
                                                     <satellite-name
-                                                            satellite-id="host.Host.satelliteId"
-                                                            ng-if="host.Host.is_satellite_host"
+                                                        satellite-id="host.Host.satelliteId"
+                                                        ng-if="host.Host.is_satellite_host"
                                                     ></satellite-name>
                                                 </td>
                                             </tr>
@@ -1085,9 +1090,10 @@ use Cake\Core\Plugin;
                                             <span ng-hide="failureDurationInPercent">
                                                     <i class="fa fa-refresh fa-spin txt-primary"></i>
                                                 </span>
-                                            <span ng-show="failureDurationInPercent">{{ (failureDurationInPercent) ? failureDurationInPercent+' %' :
-                                                    '<?php echo __('No data available !'); ?>'}}
-                                                </span>
+                                            <span
+                                                ng-show="failureDurationInPercent">{{ (failureDurationInPercent) ? failureDurationInPercent + ' %' :
+                                                    '<?php echo __('No data available!'); ?>'}}
+                                            </span>
                                         </h3>
                                     </div>
                                     <div class="col-xs-12 col-sm-12 col-md-12">
@@ -1257,7 +1263,8 @@ use Cake\Core\Plugin;
                             </div>
                         </div>
 
-                        <div class="btn-group btn-group-xs panelToolbarInput" ng-show="mergedService.service_type !== <?= PROMETHEUS_SERVICE ?>">
+                        <div class="btn-group btn-group-xs panelToolbarInput"
+                             ng-show="mergedService.service_type !== <?= PROMETHEUS_SERVICE ?>">
                             <button class="btn btn-default dropdown-toggle waves-effect waves-themed" type="button"
                                     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <?php echo __('Aggregation: '); ?>

--- a/src/Template/Services/browser.php
+++ b/src/Template/Services/browser.php
@@ -445,27 +445,29 @@ use Cake\Core\Plugin;
                                 <div class="row">
                                     <div class="col-xs-12 col-sm-12 col-md-9">
                                         <table class="table table-bordered table-sm">
-                                            <tr>
-                                                <td><?php echo __('Check command'); ?></td>
-                                                <td>
-                                                    <?php if ($this->Acl->hasPermission('edit', 'commands')): ?>
-                                                        <a ui-sref="CommandsEdit({id: checkCommand.Command.id})">
+                                            <?php if ($this->Acl->hasPermission('checkcommand', 'services')): ?>
+                                                <tr>
+                                                    <td><?php echo __('Check command'); ?></td>
+                                                    <td>
+                                                        <?php if ($this->Acl->hasPermission('edit', 'commands')): ?>
+                                                            <a ui-sref="CommandsEdit({id: checkCommand.Command.id})">
+                                                                {{ checkCommand.Command.name }}
+                                                            </a>
+                                                        <?php else: ?>
                                                             {{ checkCommand.Command.name }}
-                                                        </a>
-                                                    <?php else: ?>
-                                                        {{ checkCommand.Command.name }}
-                                                    <?php endif; ?>
-                                                </td>
-                                            </tr>
+                                                        <?php endif; ?>
+                                                    </td>
+                                                </tr>
 
-                                            <tr>
-                                                <td><?php echo __('Command line'); ?></td>
-                                                <td>
-                                                    <code class="no-background">
-                                                        {{ mergedService.serviceCommandLine }}
-                                                    </code>
-                                                </td>
-                                            </tr>
+                                                <tr>
+                                                    <td><?php echo __('Command line'); ?></td>
+                                                    <td>
+                                                        <code class="no-background">
+                                                            {{ mergedService.serviceCommandLine }}
+                                                        </code>
+                                                    </td>
+                                                </tr>
+                                            <?php endif; ?>
 
                                             <tr>
                                                 <td><?php echo __('Output'); ?></td>

--- a/src/Template/Systemsettings/index.php
+++ b/src/Template/Systemsettings/index.php
@@ -145,7 +145,7 @@
                                                                class="form-control systemsetting-input">
                                                     </div>
                                                     <div
-                                                        ng-switch-when="FRONTEND.LDAP.USE_TLS|MONITORING.SINGLE_INSTANCE_SYNC|MONITORING.HOST_CHECK_ACTIVE_DEFAULT|MONITORING.SERVICE_CHECK_ACTIVE_DEFAULT|FRONTEND.HIDDEN_USER_IN_CHANGELOG|FRONTEND.DISABLE_LOGIN_ANIMATION|FRONTEND.REPLACE_USER_MACROS|FRONTEND.REPLACE_PASSWORD_IN_OBJECT_MACROS|FRONTEND.ENABLE_IFRAME_IN_DASHBOARDS|FRONTEND.SSO.FORCE_USER_TO_LOGINPAGE"
+                                                        ng-switch-when="FRONTEND.LDAP.USE_TLS|MONITORING.SINGLE_INSTANCE_SYNC|MONITORING.HOST_CHECK_ACTIVE_DEFAULT|MONITORING.SERVICE_CHECK_ACTIVE_DEFAULT|FRONTEND.HIDDEN_USER_IN_CHANGELOG|FRONTEND.DISABLE_LOGIN_ANIMATION|FRONTEND.REPLACE_USER_MACROS|FRONTEND.REPLACE_PASSWORD_IN_OBJECT_MACROS|FRONTEND.ENABLE_IFRAME_IN_DASHBOARDS|FRONTEND.SSO.FORCE_USER_TO_LOGINPAGE|FRONTEND.BLUR_COMMAND_LINE_IN_BROWSER"
                                                         ng-switch-when-separator="|">
                                                         <select class="form-control systemsetting-input"
                                                                 ng-model="systemsetting.value">

--- a/src/itnovum/openITCOCKPIT/InitialDatabase/Systemsetting.php
+++ b/src/itnovum/openITCOCKPIT/InitialDatabase/Systemsetting.php
@@ -757,6 +757,14 @@ class Systemsetting extends Importer {
                 'created'  => '2020-04-17 08:43:17',
                 'modified' => '2020-04-17 08:43:17'
             ],
+            (int)88 => [
+                'key'      => 'FRONTEND.BLUR_COMMAND_LINE_IN_BROWSER',
+                'value'    => '0',
+                'info'     => 'If enabled the check command line in host and service browser will be displayed blurry. On mouseover the command line will be displayed normally.',
+                'section'  => 'FRONTEND',
+                'created'  => '2020-07-12 16:09:17',
+                'modified' => '2020-07-12 16:09:17'
+            ],
         ];
 
         return $data;

--- a/webroot/css/openitcockpit.css
+++ b/webroot/css/openitcockpit.css
@@ -1273,3 +1273,30 @@ label.menu-open-button:hover {
 .strikethrough {
     text-decoration: line-through;
 }
+
+
+/** Copy to clipboard button **/
+
+#copy-to-clipboard-container {
+
+}
+
+/* Hide button by default */
+.copy-to-clipboard-btn {
+    animation: fade-out .2s both;
+    display: none;
+}
+
+/* Show button on hover */
+.copy-to-clipboard-container:hover .copy-to-clipboard-btn {
+    animation: fade-in .2s both;
+    display: block;
+}
+
+.copy-to-clipboard-btn-top-right {
+    float: right;
+    padding: 0;
+}
+
+/** End copy to clipboard **/
+

--- a/webroot/css/openitcockpit.css
+++ b/webroot/css/openitcockpit.css
@@ -1277,8 +1277,7 @@ label.menu-open-button:hover {
 
 /** Copy to clipboard button **/
 
-#copy-to-clipboard-container {
-
+.copy-to-clipboard-container {
 }
 
 /* Hide button by default */
@@ -1294,8 +1293,17 @@ label.menu-open-button:hover {
 }
 
 .copy-to-clipboard-btn-top-right {
-    float: right;
-    padding: 0;
+    position: absolute;
+    top: 5px;
+    right: 5px;
+}
+
+.unblur-on-hover {
+    filter: blur(4px);
+}
+
+.unblur-on-hover:hover {
+    filter: blur(0);
 }
 
 /** End copy to clipboard **/

--- a/webroot/js/scripts/controllers/Hosts/HostsBrowserController.js
+++ b/webroot/js/scripts/controllers/Hosts/HostsBrowserController.js
@@ -163,6 +163,12 @@ angular.module('openITCOCKPIT')
                 }
 
                 $scope.init = false;
+
+                setTimeout(function(){
+                    jQuery(function(){
+                        jQuery("[rel=tooltip]").tooltip();
+                    });
+                }, 250);
             });
         };
 
@@ -622,6 +628,10 @@ angular.module('openITCOCKPIT')
         };
         /*** End of service mass change methods ***/
 
+        $scope.clipboardCommand = function(){
+            navigator.clipboard.writeText($scope.mergedHost.hostCommandLine);
+        };
+
         //Fire on page load
         $scope.loadIdOrUuid();
         $scope.loadTimezone();
@@ -640,5 +650,11 @@ angular.module('openITCOCKPIT')
             MassChangeService.setSelected($scope.massChange);
             $scope.selectedElements = MassChangeService.getCount();
         }, true);
+
+        jQuery(document).on('show.bs.tooltip', function(e){
+            setTimeout(function(){
+                jQuery('[data-toggle="tooltip"]').tooltip('hide');
+            }, 1500);
+        });
 
     });

--- a/webroot/js/scripts/controllers/Packagemanagers/PackagemanagerIndexController.js
+++ b/webroot/js/scripts/controllers/Packagemanagers/PackagemanagerIndexController.js
@@ -74,6 +74,30 @@ angular.module('openITCOCKPIT')
             return $scope.modulesToInstall.join(' \\ <br>');
         };
 
+        $scope.clipboardCommand = function(){
+            // If you change this command please make also sure to change the command in the index.php template !!
+
+            var command = 'sudo apt-get update && apt-get dist-upgrade && apt-get install ';
+            command += $scope.modulesToInstall.join(' ');
+            command += ' && echo "#########################################" && echo "Installation done. Please reload your openITCOCKPIT web interface."';
+
+            navigator.clipboard.writeText(command);
+        };
+
+        jQuery(document).ready(function(){
+            setTimeout(function(){
+                jQuery(function(){
+                    jQuery("[rel=tooltip]").tooltip();
+                });
+            }, 250);
+        });
+
+        jQuery(document).on('show.bs.tooltip', function(e){
+            setTimeout(function(){
+                jQuery('[data-toggle="tooltip"]').tooltip('hide');
+            }, 1500);
+        });
+
         //Fire on page load
         $scope.load();
 

--- a/webroot/js/scripts/controllers/Services/ServicesBrowserController.js
+++ b/webroot/js/scripts/controllers/Services/ServicesBrowserController.js
@@ -191,6 +191,12 @@ angular.module('openITCOCKPIT')
                 }
 
                 $scope.init = false;
+
+                setTimeout(function(){
+                    jQuery(function(){
+                        jQuery("[rel=tooltip]").tooltip();
+                    });
+                }, 250);
             }, function errorCallback(results){
                 if(results.status === 403){
                     $state.go('403');
@@ -868,6 +874,13 @@ angular.module('openITCOCKPIT')
             disableGraphAutorefresh();
         });
 
+
+        $scope.clipboardCommand = function(){
+            navigator.clipboard.writeText($scope.mergedService.serviceCommandLine);
+        };
+
+        // Fire on page load
+
         $scope.loadIdOrUuid();
 
         $scope.$watch('servicestatus.isFlapping', function(){
@@ -902,6 +915,12 @@ angular.module('openITCOCKPIT')
                 return;
             }
             loadGraph($scope.host.Host.uuid, $scope.mergedService.uuid, false, lastGraphStart, lastGraphEnd, false);
+        });
+
+        jQuery(document).on('show.bs.tooltip', function(e){
+            setTimeout(function(){
+                jQuery('[data-toggle="tooltip"]').tooltip('hide');
+            }, 1500);
         });
 
     });


### PR DESCRIPTION
User Role Permissions
- hosts/checkcommand: When disabled the user can not see the check command line of the host in /hosts/browser anymore. The command is also removed fom the API response.
- service/checkcommand: When disabled the user can not see the check command line of the service in /services/browser anymore. The command is also removed fom the API response.

New Systemsetting ` BLUR_COMMAND_LINE_IN_BROWSER `:
 - When enabled the check command line in /hosts/browser and /services/browser will be displayed blurry by default. When the user hovers over the blurry command line the text will be displayed normally. This will prevent the user from accidentally leaking sensitive information while the PC is connected to a projector or a screen sharing session is running.

Copy to clipboard:
 - When hovering over the check command line, event when `BLUR_COMMAND_LINE_IN_BROWSER` is enabled, the interface will display a "Copy to clipboard" button.

This implements the Feature Request from: https://github.com/it-novum/openITCOCKPIT/pull/1193