### PR TITLE
ITC-2703 host dependency - rename "recovery" to "up"

### DIFF
--- a/src/Template/Hostdependencies/add.php
+++ b/src/Template/Hostdependencies/add.php
@@ -235,7 +235,7 @@ $timezones = \itnovum\openITCOCKPIT\Core\Timezone::listTimezones();
                                                ng-model="post.Hostdependency.execution_fail_on_up">
                                         <label class="custom-control-label"
                                                for="execution_fail_on_up">
-                                            <span class="badge badge-success notify-label"><?php echo __('Recovery'); ?></span>
+                                            <span class="badge badge-success notify-label"><?php echo __('Up'); ?></span>
                                             <i class="checkbox-success"></i>
                                         </label>
                                     </div>
@@ -318,7 +318,7 @@ $timezones = \itnovum\openITCOCKPIT\Core\Timezone::listTimezones();
                                                ng-model="post.Hostdependency.notification_fail_on_up">
                                         <label class="custom-control-label"
                                                for="notification_fail_on_up">
-                                            <span class="badge badge-success notify-label"><?php echo __('Recovery'); ?></span>
+                                            <span class="badge badge-success notify-label"><?php echo __('Up'); ?></span>
                                             <i class="checkbox-success"></i>
                                         </label>
                                     </div>

--- a/src/Template/Hostdependencies/edit.php
+++ b/src/Template/Hostdependencies/edit.php
@@ -236,7 +236,7 @@ $timezones = \itnovum\openITCOCKPIT\Core\Timezone::listTimezones();
                                                ng-model="post.Hostdependency.execution_fail_on_up">
                                         <label class="custom-control-label"
                                                for="execution_fail_on_up">
-                                            <span class="badge badge-success notify-label"><?php echo __('Recovery'); ?></span>
+                                            <span class="badge badge-success notify-label"><?php echo __('Up'); ?></span>
                                             <i class="checkbox-success"></i>
                                         </label>
                                     </div>
@@ -319,7 +319,7 @@ $timezones = \itnovum\openITCOCKPIT\Core\Timezone::listTimezones();
                                                ng-model="post.Hostdependency.notification_fail_on_up">
                                         <label class="custom-control-label"
                                                for="notification_fail_on_up">
-                                            <span class="badge badge-success notify-label"><?php echo __('Recovery'); ?></span>
+                                            <span class="badge badge-success notify-label"><?php echo __('Up'); ?></span>
                                             <i class="checkbox-success"></i>
                                         </label>
                                     </div>


### PR DESCRIPTION
This is now the same wording as used for Services and also as preferred by Naemon itself: https://www.naemon.org/documentation/usersguide/objectdefinitions.html#host_dependency_definition