### PR TITLE
Prevent wrong values due to curvedLines

### DIFF
--- a/webroot/js/scripts/controllers/Services/ServicesBrowserController.js
+++ b/webroot/js/scripts/controllers/Services/ServicesBrowserController.js
@@ -638,7 +638,7 @@ angular.module('openITCOCKPIT')
                 // https://github.com/MichaelZinsmaier/CurvedLines
                 curvedLines: {
                     apply: true,
-                    //monotonicFit: true
+                    monotonicFit: true
                 }
             }], options);
 


### PR DESCRIPTION
From the Readme: https://github.com/MichaelZinsmaier/CurvedLines The old fit option has been replaced with monotonicFit, which if set, enforces the use of the Fritsch-Carlson method (anti wiggle no overshooting / undershooting).