### PR TITLE
ITC-2893 Show main menu on mobile devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ plugins/ORACLEModule
 plugins/UPSModule
 plugins/VMwareSnapshotModule
 plugins/CustomalertModule
+plugins/SLAModule

--- a/src/Template/Angular/menu_control.php
+++ b/src/Template/Angular/menu_control.php
@@ -24,6 +24,7 @@
 //  confirmation.
 ?>
 
+<!-- Desktop menu button -->
 <div class="hidden-md-down dropdown-icon-menu position-relative">
     <a href="javascript:void(0);" class="header-btn btn js-waves-off" data-action="toggle" ng-click="toggleMenuHidden()"
        data-class="nav-function-hidden" title="Hide Navigation">
@@ -48,4 +49,12 @@
             <i class="fas fa-bars"></i>
         </a>
     </div>
+</div>
+
+
+<!-- Mobile menu button -->
+<div class="hidden-lg-up">
+    <a href="#" class="header-btn btn press-scale-down" data-action="toggle" data-class="mobile-nav-on">
+        <i class="ni ni-menu"></i>
+    </a>
 </div>

--- a/src/Template/element/header.php
+++ b/src/Template/element/header.php
@@ -25,11 +25,11 @@
 ?>
 <header id="header" class="page-header" role="banner">
     <menu-control></menu-control>
-    <div class="search" top-search=""></div>
+    <div class="search hidden-lg-down" top-search=""></div>
     <div class="ml-auto d-flex">
 
         <?php if ($hasSubscription === false): ?>
-            <div class="header-icon padding-left-10 padding-right-5">
+            <div class="header-icon padding-left-10 padding-right-5 hidden-md-down">
                 <a class="btn btn-outline-danger waves-effect waves-themed"
                    href="https://openitcockpit.io/editions/"
                    target="_blank"
@@ -42,7 +42,7 @@
         <?php endif; ?>
 
         <?php if ($hasSubscription === true && $isCommunityEdition === true): ?>
-            <div class="header-icon padding-left-10 padding-right-5">
+            <div class="header-icon padding-left-10 padding-right-5 hidden-md-down">
                 <a class="btn btn-outline-primary waves-effect waves-themed"
                    href="https://openitcockpit.io/editions/"
                    target="_blank"
@@ -55,13 +55,13 @@
         <?php endif; ?>
 
 
-        <div class="header-icon padding-left-5">
+        <div class="header-icon padding-left-5 hidden-md-down">
             <menustats></menustats>
         </div>
-        <div class="header-icon">
+        <div class="header-icon hidden-md-down">
             <system-health></system-health>
         </div>
-        <div class="header-icon">
+        <div class="header-icon hidden-md-down">
             <span id="global_ajax_loader" style="display: none;">
                 <div class="spinner-border spinner-border-sm" role="status">
                     <span class="sr-only">
@@ -97,7 +97,7 @@
                 <?php endif; ?>
             </span>
         </div>
-        <div class="header-icon padding-left-5">
+        <div class="header-icon padding-left-5 hidden-md-down">
             <version-check></version-check>
         </div>
         <div class="header-icon padding-left-5">

--- a/src/Template/layout/app_frame.php
+++ b/src/Template/layout/app_frame.php
@@ -217,6 +217,8 @@ if (ENVIRONMENT === Environments::PRODUCTION) {
                     </div>
                 </div>
             </main>
+            <!-- this overlay is activated only when mobile menu is triggered -->
+            <div class="page-content-overlay" data-action="toggle" data-class="mobile-nav-on"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Makes it possible to use the main menu on mobile devices.
Please notice: openITCOCKPIT itself is not very mobile frindly. If you are looking for a mobile version of openITCOCKPIT, please have a look at: https://openitcockpit.io/2022/2022/10/28/openitcockpit-mobile-1-2-released/

And: https://docs.openitcockpit.io/en/additional/mobile-website/