### PR TITLE
addOptionForLdapOauth

### DIFF
--- a/src/Model/Table/SystemsettingsTable.php
+++ b/src/Model/Table/SystemsettingsTable.php
@@ -265,6 +265,17 @@ class SystemsettingsTable extends Table {
         }
     }
 
+    public function isLdapAllowedForOauth() {
+        try {
+            $result = $this->getSystemsettingByKey('FRONTEND.LDAP.OAUTH_ALLOWED');
+            
+            $value = (int)$result->get('value');
+            return $value === 1;
+        } catch (\Exception $e) {
+            return false;
+        }
+    } 
+
     public function getOAuthConfig() {
         $query = $this->find()
             ->where([

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -1010,15 +1010,25 @@ class UsersTable extends Table {
      * @return array|EntityInterface|null
      */
     public function getOAuthUserByEmailForLogin(string $email) {
+        $SystemsettingsTable = TableRegistry::getTableLocator()->get('Systemsettings');
         $query = $this->find();
-        return $query
+        if ($SystemsettingsTable->isLdapAllowedForOauth()) {
+            return $query
+            ->where([
+                            'Users.email'     => $email,
+                            'Users.is_active' => 1
+            ])
+            ->first();
+        } else {
+            return $query
             ->where([
                 'Users.email'     => $email,
                 'Users.is_active' => 1,
                 'Users.is_oauth'  => 1
             ])
             ->first();
-    }
+        }    
+    }     
 
     /**
      * May deprecated functions after fully moving to cakephp 4

--- a/src/Template/Systemsettings/index.php
+++ b/src/Template/Systemsettings/index.php
@@ -199,6 +199,13 @@
                                                             <option value="AzureActiveDirectory"><?php echo __('Azure Active Directory'); ?></option>
                                                         </select>
                                                     </div>
+                                                    <div ng-switch-when="FRONTEND.LDAP.OAUTH_ALLOWED">
+                                                        <select class="form-control systemsetting-input"
+                                                                ng-model="systemsetting.value">
+                                                            <option value="1"><?php echo __('True'); ?></option>
+                                                            <option value="0"><?php echo __('False'); ?></option>
+                                                        </select>
+                                                    </div>
                                                     <div ng-switch-default>
                                                         <input type="text"
                                                                ng-model="systemsetting.value"

--- a/src/itnovum/openITCOCKPIT/InitialDatabase/Systemsetting.php
+++ b/src/itnovum/openITCOCKPIT/InitialDatabase/Systemsetting.php
@@ -885,6 +885,15 @@ class Systemsetting extends Importer {
                 'created'  => '2020-01-29 09:28:17',
                 'modified' => '2020-01-29 09:28:17'
             ],
+            (int)104  => [
+                'key'      => 'FRONTEND.LDAP.OAUTH_ALLOWED',
+                'value'    => '0',
+                'info'     => 'Allow LDAP users to use oAuth authentification',
+                'section'  => 'FRONTEND',
+                'created'  => '2020-01-29 09:28:17',
+                'modified' => '2020-01-29 09:28:17'
+
+            ],
         ];
 
         return $data;


### PR DESCRIPTION
Hallo,
folgender Use-Case: Unser Reverse Proxy befüllt LDAP Gruppen über Rollen und dient zugleich als oAuth Endpunkt.
Jetzt erscheint es sinnvoll, wenn auch LDAP User sich über Single Sign On einloggen können um die User-Session vom Reverse Proxy mitzubenutzen.
Momentan sehe ich nur die Möglichkeit SSO für lokale Benutzer zu aktivieren. Deshalb hier eine Idee um auch SSO LDAP Usern zur Verfügung zu stellen