### PR TITLE
ITC-3025 Add tags to CSV export of hosts and services

### DIFF
--- a/src/Controller/HostsController.php
+++ b/src/Controller/HostsController.php
@@ -2511,12 +2511,18 @@ class HostsController extends AppController {
                 $satelliteName = $satellites[$Host->getSatelliteId()];
             }
 
+            $tags = $Host->getTags();
+            if (empty($tags)) {
+                $tags = $Hosttemplate->getTags();
+            }
+
             $all_hosts[] = [
                 $Host->getHostname(),
                 $Host->getId(),
                 $Host->getUuid(),
                 $Host->getAddress(),
                 $Host->getDescription(),
+                $tags,
                 $Host->getHosttemplateId(),
                 $Hosttemplate->getName(),
                 $Host->getSatelliteId(),
@@ -2540,6 +2546,7 @@ class HostsController extends AppController {
             'host_uuid',
             'host_address',
             'host_description',
+            'host_tags',
             'hosttemplate_id',
             'hosttemplate_name',
             'satellite_id',

--- a/src/Controller/ServicesController.php
+++ b/src/Controller/ServicesController.php
@@ -36,6 +36,7 @@ use App\Lib\Interfaces\HoststatusTableInterface;
 use App\Lib\Interfaces\ServicestatusTableInterface;
 use App\Lib\Traits\PluginManagerTableTrait;
 use App\Model\Entity\Changelog;
+use App\Model\Entity\Servicetemplate;
 use App\Model\Table\ChangelogsTable;
 use App\Model\Table\CommandargumentsTable;
 use App\Model\Table\CommandsTable;
@@ -2018,11 +2019,17 @@ class ServicesController extends AppController {
             $Service = new Service($service);
             $Servicestatus = new Servicestatus($service['Servicestatus'], $UserTime);
 
+            $tags = $Service->getTags();
+            if (empty($tags)) {
+                $tags = $service['_matchingData']['Servicetemplates']['tags'];
+            }
+
             $all_services[] = [
                 $Service->getServicename(),
                 $Service->getId(),
                 $Service->getUuid(),
                 $Service->getDescription(),
+                $tags,
                 $service['_matchingData']['Servicetemplates']['id'],
                 $service['_matchingData']['Servicetemplates']['name'],
 
@@ -2047,6 +2054,7 @@ class ServicesController extends AppController {
             'service_id',
             'service_uuid',
             'service_description',
+            'service_tags',
             'servicetemplate_id',
             'servicetemplate_name',
 


### PR DESCRIPTION
* Add tags of host or host-template to CSV export.
* Service index CSV export shows tags of the service or the service template if defined.
