### PR TITLE
IPv6 compatibility of agent

### DIFF
--- a/src/itnovum/openITCOCKPIT/Agent/AgentHttpClient.php
+++ b/src/itnovum/openITCOCKPIT/Agent/AgentHttpClient.php
@@ -74,6 +74,11 @@ class AgentHttpClient {
         $this->config = $AgentConfiguration->unmarshal($agentconfig->config);
 
         $this->hostaddress = $hostaddress;
+        // Encapsulate IPv6 address in [...] for use in curl URLs
+        if(filter_var($hostaddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            $this->hostaddress = sprintf('[%s]', $hostaddress);
+        }
+
         $this->port = $this->config['int']['bind_port'];
 
         $protocol = 'https';
@@ -83,7 +88,7 @@ class AgentHttpClient {
         }
 
         // e.g.: https://127.0.0.1:3333
-        $this->baseUrl = sprintf('%s://%s:%s', $protocol, $hostaddress, $this->port);
+        $this->baseUrl = sprintf('%s://%s:%s', $protocol, $this->hostaddress, $this->port);
     }
 
 


### PR DESCRIPTION
Fixes ipv6 addresses for curl calls.
When using Agent discovery with ipv6 address for the host there is an error otherwise like
```
Could not establish HTTP connection for AutoTLS certificate exchange.
cURL error 3: (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://2001:xxxx:xxxx:xxxx::x:3333/autotls
```

Additionally should patch receiver/src/itnovum/openITCOCKPIT/Checks/Receiver/ValueObjects/TargetHost.php
```
54,57d53
<         // Encapsulate IPv6 address in [...] for use in URLs
<         if(filter_var($this->config['address'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
<             return sprintf('[%s]', $this->config['address']);
<         }
```
