### PR TITLE
ITC-3122 Refactor permissions check of the Map Module.

### DIFF
--- a/plugins/MapModule/src/Controller/MapeditorsController.php
+++ b/plugins/MapModule/src/Controller/MapeditorsController.php
@@ -26,7 +26,6 @@
 namespace MapModule\Controller;
 
 use App\Lib\Exceptions\MissingDbBackendException;
-use App\Model\Table\ContainersTable;
 use App\Model\Table\HostgroupsTable;
 use App\Model\Table\HostsTable;
 use App\Model\Table\ServicegroupsTable;
@@ -281,7 +280,7 @@ class MapeditorsController extends AppController {
                     $HostgroupsTable = TableRegistry::getTableLocator()->get('Hostgroups');
 
                     $hostgroup = $HostgroupsTable->getHostsByHostgroupForMaps($objectId, $MY_RIGHTS);
-                    if(!isset($hostgroup['hosts'])){
+                    if (!isset($hostgroup['hosts'])) {
                         $hostgroup['hosts'] = [];
                     }
 
@@ -314,8 +313,8 @@ class MapeditorsController extends AppController {
                 $ServicegroupsTable = TableRegistry::getTableLocator()->get('Servicegroups');
                 try {
                     $servicegroup = $ServicegroupsTable->getServicegroupsByServicegroupForMaps($objectId, $MY_RIGHTS);
-                    if(!isset($servicegroup['services'] )){
-                        $servicegroup['services']  = [];
+                    if (!isset($servicegroup['services'])) {
+                        $servicegroup['services'] = [];
                     }
                     $servicegroup['services'] = array_merge(
                         $servicegroup['services'],
@@ -342,9 +341,6 @@ class MapeditorsController extends AppController {
                 break;
             case 'map':
                 $map = $MapsTable->getMapsForMaps($objectId, $mapId, false);
-                if(empty($map)){
-                    $map = $MapsTable->getMapsForMapsummaryitems($objectId, $mapId, false);
-                }
                 if (!empty($map)) {
                     if ($this->hasRootPrivileges === false) {
                         if (!$this->allowedByContainerId(Hash::extract($map, 'containers.{n}.id'), false)) {
@@ -362,32 +358,6 @@ class MapeditorsController extends AppController {
                     $HostgroupsTable = TableRegistry::getTableLocator()->get('Hostgroups');
                     /** @var ServicegroupsTable $ServicegroupsTable */
                     $ServicegroupsTable = TableRegistry::getTableLocator()->get('Servicegroups');
-
-                    //fetch all dependent map items after permissions check
-                    $mapSummaryItemToResolve = $MapsummaryitemsTable->getMapsummaryitemsForMaps($map['id'], $mapId);
-
-                    if (!empty($mapSummaryItemToResolve)) {
-                        $allVisibleItems = $MapsummaryitemsTable->allVisibleMapsummaryitems($mapId, $MY_RIGHTS);
-                        $mapIdGroupByMapId = Hash::combine(
-                            $allVisibleItems,
-                            '{n}.object_id',
-                            '{n}.object_id',
-                            '{n}.map_id'
-                        );
-                        if (isset($mapIdGroupByMapId[$objectId])) {
-                            $dependentMapsIds = $this->getDependendMaps($mapIdGroupByMapId, $objectId);
-                        }
-                        $dependentMapsIds[] = $objectId;
-
-                        // resolve all Elements (host and/or services of dependent map)
-                        $allDependentMapElementsFromSubMaps['mapsummaryitem'] = $MapsTable->getAllDependentMapsElements(
-                            $dependentMapsIds,
-                            $HostgroupsTable,
-                            $ServicegroupsTable,
-                            $MY_RIGHTS
-                        );
-                    }
-
                     //fetch all dependent map items after permissions check
                     $mapItemToResolve = $MapitemsTable->getMapitemsForMaps($map['id'], $mapId);
                     if (empty($mapItemToResolve)) {
@@ -415,7 +385,7 @@ class MapeditorsController extends AppController {
                         $dependentMapsIds[] = $objectId;
 
                         // resolve all Elements (host and/or services of dependent map)
-                        $allDependentMapElementsFromSubMaps['mapitem']  = $MapsTable->getAllDependentMapsElements(
+                        $allDependentMapElementsFromSubMaps['mapitem'] = $MapsTable->getAllDependentMapsElements(
                             $dependentMapsIds,
                             $HostgroupsTable,
                             $ServicegroupsTable,
@@ -624,7 +594,7 @@ class MapeditorsController extends AppController {
                 $HostgroupsTable = TableRegistry::getTableLocator()->get('Hostgroups');
 
                 $hostgroup = $HostgroupsTable->getHostgroupByIdForMapeditor($objectId, $MY_RIGHTS);
-                if(!isset($hostgroup['hosts'])){
+                if (!isset($hostgroup['hosts'])) {
                     $hostgroup['hosts'] = [];
                 }
                 $hostgroup['hosts'] = array_merge(
@@ -658,7 +628,7 @@ class MapeditorsController extends AppController {
                 $ServicegroupsTable = TableRegistry::getTableLocator()->get('Servicegroups');
 
                 $servicegroup = $ServicegroupsTable->getServicegroupByIdForMapeditor($objectId, $MY_RIGHTS);
-                if(!isset($servicegroup['services'])){
+                if (!isset($servicegroup['services'])) {
                     $servicegroup['services'] = [];
                 }
                 $servicegroup['services'] = array_merge(
@@ -1000,7 +970,7 @@ class MapeditorsController extends AppController {
             case 'hostgroup':
                 try {
                     $hostgroup = $HostgroupsTable->getHostsByHostgroupForMaps($objectId, $MY_RIGHTS);
-                    if(!isset($hostgroup['hosts'])){
+                    if (!isset($hostgroup['hosts'])) {
                         $hostgroup['hosts'] = [];
                     }
                     $hostgroup['hosts'] = array_merge(
@@ -1025,7 +995,7 @@ class MapeditorsController extends AppController {
                 break;
             case 'servicegroup':
                 $servicegroup = $ServicegroupsTable->getServicegroupByIdForMapeditor($objectId, $MY_RIGHTS);
-                if(!isset($servicegroup['services'])){
+                if (!isset($servicegroup['services'])) {
                     $servicegroup['services'] = [];
                 }
                 $servicegroup['services'] = array_merge(

--- a/plugins/MapModule/src/Model/Table/MapsTable.php
+++ b/plugins/MapModule/src/Model/Table/MapsTable.php
@@ -1051,6 +1051,7 @@ class MapsTable extends Table {
 
         }
 
+
         if (!empty($mapElementsByCategory['servicegroup'])) {
             foreach ($mapElementsByCategory['servicegroup'] as $servicegroupId) {
                 $serviceIds = array_merge(

--- a/plugins/MapModule/webroot/js/scripts/directives/MapItemDirective.js
+++ b/plugins/MapModule/webroot/js/scripts/directives/MapItemDirective.js
@@ -14,6 +14,11 @@ angular.module('openITCOCKPIT').directive('mapItem', function($http, $interval, 
             var interval = null;
 
             var updateCallback = function(result){
+                if(!result.data.allowView){
+                    $scope.allowView = false;
+                    return;
+                }
+
                 $scope.icon = result.data.data.icon;
                 $scope.icon_property = result.data.data.icon_property;
                 $scope.allowView = result.data.allowView;

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -154,8 +154,7 @@ class AppController extends Controller {
             return false;
         }
 
-        /** @var $ContainersTable ContainersTable */
-        $ContainersTable = TableRegistry::getTableLocator()->get('Containers');
+
         $rights = $this->MY_RIGHTS;
 
         if (is_array($containerIds)) {

--- a/src/Model/Table/ServicesTable.php
+++ b/src/Model/Table/ServicesTable.php
@@ -3535,10 +3535,11 @@ class ServicesTable extends Table {
 
     /**
      * @param $ids
+     * @param array $MY_RIGHTS
      * @param bool $enableHydration
      * @return array
      */
-    public function getServicesByIdsForMapeditor($ids, $enableHydration = false) {
+    public function getServicesByIdsForMapeditor($ids, array $MY_RIGHTS = [], $enableHydration = false) {
         if (!is_array($ids)) {
             $ids = [$ids];
         }
@@ -3547,7 +3548,7 @@ class ServicesTable extends Table {
                 [
                     'table'      => 'hosts',
                     'alias'      => 'Hosts',
-                    'type'       => 'LEFT',
+                    'type'       => 'INNER',
                     'conditions' => [
                         'Hosts.id = Services.host_id',
                     ],
@@ -3555,7 +3556,7 @@ class ServicesTable extends Table {
                 [
                     'table'      => 'hosts_to_containers',
                     'alias'      => 'HostsToContainers',
-                    'type'       => 'LEFT',
+                    'type'       => 'INNER',
                     'conditions' => [
                         'HostsToContainers.host_id = Hosts.id',
                     ],
@@ -3570,7 +3571,15 @@ class ServicesTable extends Table {
             ])->where([
                 'Services.id IN'    => $ids,
                 'Services.disabled' => 0
-            ])->enableHydration($enableHydration);
+            ]);
+
+        if (!empty($MY_RIGHTS)) {
+            $query->where([
+                'HostsToContainers.container_id IN' => $MY_RIGHTS
+            ]);
+        }
+
+        $query->enableHydration($enableHydration);
 
         $result = $query->toArray();
         if (empty($result)) {
@@ -3582,9 +3591,10 @@ class ServicesTable extends Table {
     /**
      * @param $ids
      * @param bool $enableHydration
+     * @param array $MY_RIGHTS
      * @return array
      */
-    public function getServicesByIdsForMapsumary($ids, $enableHydration = false) {
+    public function getServicesByIdsForMapsumary($ids, $MY_RIGHTS = [], $enableHydration = false) {
         if (!is_array($ids)) {
             $ids = [$ids];
         }
@@ -3593,7 +3603,7 @@ class ServicesTable extends Table {
                 [
                     'table'      => 'hosts',
                     'alias'      => 'Hosts',
-                    'type'       => 'LEFT',
+                    'type'       => 'INNER',
                     'conditions' => [
                         'Hosts.id = Services.host_id',
                     ],
@@ -3601,7 +3611,7 @@ class ServicesTable extends Table {
                 [
                     'table'      => 'hosts_to_containers',
                     'alias'      => 'HostsToContainers',
-                    'type'       => 'LEFT',
+                    'type'       => 'INNER',
                     'conditions' => [
                         'HostsToContainers.host_id = Hosts.id',
                     ],
@@ -3626,7 +3636,16 @@ class ServicesTable extends Table {
         ])->where([
             'Services.id IN'    => $ids,
             'Services.disabled' => 0
-        ])->enableHydration($enableHydration);
+        ]);
+        if (!empty($MY_RIGHTS)) {
+            $query->where([
+                'HostsToContainers.container_id IN' => $MY_RIGHTS
+            ]);
+        }
+        $query->group([
+            'Services.id'
+        ]);
+        $query->enableHydration($enableHydration);
 
         $result = $query->toArray();
         if (empty($result)) {


### PR DESCRIPTION
Most SQL queries will now use MY_RIGHTS to filter the result of hosts, services host groups and service groups instead of depending on AppController::allowedByContainerId which was never build to check the permissions of multiple objects at once