### PR TITLE
ITC-3127 OpenLDAP: Add support for uniqueMember (RFC4519 2.40)

### DIFF
--- a/src/Template/Systemsettings/index.php
+++ b/src/Template/Systemsettings/index.php
@@ -199,6 +199,13 @@
                                                             <option value="AzureActiveDirectory"><?php echo __('Azure Active Directory'); ?></option>
                                                         </select>
                                                     </div>
+                                                    <div ng-switch-when="FRONTEND.LDAP.OPENLDAP_GROUP_SCHEMA">
+                                                        <select class="form-control systemsetting-input"
+                                                                ng-model="systemsetting.value">
+                                                            <option value="memberUid"><?php echo __('memberUid (deprecated)'); ?></option>
+                                                            <option value="uniqueMember"><?php echo __('uniqueMember (RFC 4519 2.40)'); ?></option>
+                                                        </select>
+                                                    </div>
                                                     <div ng-switch-default>
                                                         <input type="text"
                                                                ng-model="systemsetting.value"

--- a/src/itnovum/openITCOCKPIT/InitialDatabase/Systemsetting.php
+++ b/src/itnovum/openITCOCKPIT/InitialDatabase/Systemsetting.php
@@ -885,6 +885,14 @@ class Systemsetting extends Importer {
                 'created'  => '2020-01-29 09:28:17',
                 'modified' => '2020-01-29 09:28:17'
             ],
+            (int)104  => [
+                'key'      => 'FRONTEND.LDAP.OPENLDAP_GROUP_SCHEMA',
+                'value'    => 'memberUid',
+                'info'     => 'Specifying Group Memberships by Using the memberUid or uniqueMember (RFC 4519 2.40) attribute for OpenLDAP servers',
+                'section'  => 'FRONTEND',
+                'created'  => '2022-01-06 08:52:17',
+                'modified' => '2022-01-06 08:52:17'
+            ],
         ];
 
         return $data;


### PR DESCRIPTION
This PR adds a new system setting to switch LDAP group membership between the `memberUid`  and `uniqueMember` attribute 

When the `uniqueMember` attribute  is used, the generated filter will look like so:
```
(&(ObjectClass=posixGroup)(uniqueMember=uid=dziegler*))
```

By default openITCOCKPIT will use `memberUid` (current behavior) which uses this LDAP query:
```
(&(ObjectClass=posixGroup)(memberUid=dziegler))
```

@kbilev already patched this using a more generic query, which unfortunately broke some OpenLDAP setups
Original PR: https://github.com/it-novum/openITCOCKPIT/pull/1500