### PR TITLE
openITCOCKPIT 5.1.0-1

### DIFF
--- a/src/itnovum/openITCOCKPIT/Core/MonitoringEngine/NagiosConfigGenerator.php
+++ b/src/itnovum/openITCOCKPIT/Core/MonitoringEngine/NagiosConfigGenerator.php
@@ -2620,9 +2620,7 @@ class NagiosConfigGenerator {
             $servicegroupIds = [];
             $dependentServicegroupIds = [];
 
-            $services = $servicedependency->get('services',
-                contain: ['Hosts']
-            );
+            $services = $servicedependency->get('services');
 
             $servicegroupsForCfg = [];
             $dependentServicegroupsForCfg = [];


### PR DESCRIPTION
Fix Export of Servicedependencies
error: [Error] Unknown named parameter $contain in /opt/openitc/frontend/src/itnovum/openITCOCKPIT/Core/MonitoringEngine/NagiosConfigGenerator.php on line 2624