### PR TITLE
ITC-3578 Set the same timezone for the MySQL connection as PHP uses

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,5 +1,6 @@
 <?php
-// Copyright (C) <2015-present>  <it-novum GmbH>
+// Copyright (C) 2015-2025  it-novum GmbH
+// Copyright (C) 2025-today Allgeier IT Services GmbH
 //
 // This file is dual licensed
 //

--- a/config/datasource.php
+++ b/config/datasource.php
@@ -1,6 +1,35 @@
 <?php
+// Copyright (C) 2015-2025  it-novum GmbH
+// Copyright (C) 2025-today Allgeier IT Services GmbH
+//
+// This file is dual licensed
+//
+// 1.
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, version 3 of the License.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// 2.
+//     If you purchased an openITCOCKPIT Enterprise Edition you can use this file
+//     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
+//     License agreement and license key will be shipped with the order
+//     confirmation.
+
 $mcp = new \App\itnovum\openITCOCKPIT\Database\MysqlConfigFileParser();
 $ini_file = $mcp->parse_mysql_cnf('/opt/openitc/etc/mysql/mysql.cnf');
+
+$timezone = date_default_timezone_get();
+if (empty($timezone)) {
+    $timezone = 'UTC';
+}
 
 return [
     'Datasources' => [
@@ -22,7 +51,7 @@ return [
              * You do not need to set this flag to use full utf-8 encoding (internal default since CakePHP 3.6).
              */
             'encoding'         => 'utf8mb4',
-            'timezone'         => 'UTC',
+            'timezone'         => $timezone,
             'flags'            => [],
             'cacheMetadata'    => true,
             'log'              => false,
@@ -51,7 +80,7 @@ return [
             'password'         => $ini_file['password'],
             'database'         => $ini_file['database'],
             'encoding'         => 'utf8mb4',
-            'timezone'         => 'UTC',
+            'timezone'         => $timezone,
             'cacheMetadata'    => true,
             'quoteIdentifiers' => false,
             'log'              => false,


### PR DESCRIPTION
This ensures that PHPs time() and date() will return the same results as MySQLs NOW() and other DATE functions