### PR TITLE
ITC-3599 - Performance Data: Wrong min and max values for percentages

### DIFF
--- a/src/itnovum/openITCOCKPIT/Perfdata/NagiosAdapter.php
+++ b/src/itnovum/openITCOCKPIT/Perfdata/NagiosAdapter.php
@@ -94,6 +94,10 @@ final class NagiosAdapter extends PerformanceDataAdapter {
                     $scaleMin = 0;
                     $scaleMax = 100;
                 }
+
+                // Ensure the scale includes the current value.
+                $scaleMin = min($current, $scaleMin);
+                $scaleMax = max($scaleMax, $current);
             }
         } else {
             $scaleMin = (float)$scaleMin;


### PR DESCRIPTION
* Ensure that the scale contains the current value.