### PR TITLE
ITC-3837: Core & Satellite API: Cookie Defaults not strict enough

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -317,5 +317,11 @@ return [
      */
     'Session'   => [
         'defaults' => env('OITC_SESSION_DEFAULTS', 'php'),
+        'ini'      => [
+            'session.cookie_httponly' => 1,
+            'session.cookie_secure'   => 1,
+            'session.cookie_samesite' => 'Lax',
+            'session.use_strict_mode' => 1
+        ]
     ],
 ];

--- a/src/Application.php
+++ b/src/Application.php
@@ -197,7 +197,10 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             'fields'          => $fields,
             'rememberMeField' => 'remember_me',
             'cookie'          => [
-                'expires' => $expireAt
+                'expires'  => $expireAt,
+                'httponly' => true,
+                'secure'   => true,
+                'samesite' => CookieInterface::SAMESITE_LAX
             ]
         ]);
         $service->loadAuthenticator('Authentication.Session', [


### PR DESCRIPTION
* Harden default Cookie handling for sessions
* Harden the remember-me Cookie